### PR TITLE
Style author byline in blog posts

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -2,7 +2,7 @@
 
     <article class="post auto xl-paragraph">
         <h1>{{ title }}</h1>
-        <p>{{ author }}</p>
+        <p class="byline">{{ date }} - {{ author }}</p>
         {{ content | safe }}
     </article>
 

--- a/css/general.css
+++ b/css/general.css
@@ -58,6 +58,11 @@ p, li, table, pre, button {
   max-width: 23ch;
 }
 
+.byline {
+  font-size: 1.2rem;
+  opacity: .5;
+}
+
 .post-item-title {
   margin: var(--zero);
   font-weight: 500;


### PR DESCRIPTION
This is a bit more speculative and I'd love feedback on whether it's a good approach.

But at the moment the author byline in blog post pages like https://bright-youtiao-89f500.netlify.app/content/posts/markdown-conversion/ is styled the same way as the text, so it looks kind of like part of the text. This PR is intended to make it clearer that it's a different thing.

I also included the date, not so much because it's that important but because I think it helps convey the idea that this is a byline and not part of the article content.
